### PR TITLE
Ntp

### DIFF
--- a/tasks/level-1/2.1.1.3.yml
+++ b/tasks/level-1/2.1.1.3.yml
@@ -17,3 +17,16 @@
 - fail:
     msg: No server or pool seems to be configured for Chrony. Please fix this as per item 2.1.1.3 of the benchmark, and re-run this play.
   when: line_matched == "0"
+
+- name: 2.1.1.3 remove ntp pool and replace with amazon time server
+  replace:
+    path: /etc/chrony.d/ntp-pool.sources
+    regexp: '^pool [0-2]\.amazon\.pool\.ntp\.org iburst maxsources [1-2]'
+    replace: ''
+  lineinfile:
+    path: /etc/chrony.d/ntp-pool.sources
+    line: 'server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4'
+    insertafter: EOF
+      
+
+

--- a/tasks/level-1/2.1.1.3.yml
+++ b/tasks/level-1/2.1.1.3.yml
@@ -17,16 +17,3 @@
 - fail:
     msg: No server or pool seems to be configured for Chrony. Please fix this as per item 2.1.1.3 of the benchmark, and re-run this play.
   when: line_matched == "0"
-
-- name: 2.1.1.3 remove ntp pool and replace with amazon time server
-  replace:
-    path: /etc/chrony.d/ntp-pool.sources
-    regexp: '^pool [0-2]\.amazon\.pool\.ntp\.org iburst maxsources [1-2]'
-    replace: ''
-  lineinfile:
-    path: /etc/chrony.d/ntp-pool.sources
-    line: 'server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4'
-    insertafter: EOF
-      
-
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,3 +11,5 @@
 - include_tasks: "level-2.yml"
 # become: yes
   when: cis_apply_level_2_profile
+
+- include_tasks: "ntp_pool.yml"

--- a/tasks/ntp_pool.yml
+++ b/tasks/ntp_pool.yml
@@ -1,0 +1,11 @@
+---
+
+- name: remove ntp pool and replace with amazon time server
+  replace:
+    path: /etc/chrony.d/ntp-pool.sources
+    regexp: '^pool [0-2]\.amazon\.pool\.ntp\.org iburst maxsources [1-2]'
+    replace: ''
+  lineinfile:
+    path: /etc/chrony.d/ntp-pool.sources
+    line: 'server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4'
+    insertafter: EOF

--- a/tasks/ntp_pool.yml
+++ b/tasks/ntp_pool.yml
@@ -5,6 +5,8 @@
     path: /etc/chrony.d/ntp-pool.sources
     regexp: '^pool [0-2]\.amazon\.pool\.ntp\.org iburst maxsources [1-2]'
     replace: ''
+  
+- name: 
   lineinfile:
     path: /etc/chrony.d/ntp-pool.sources
     line: 'server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4'


### PR DESCRIPTION
Time synchronization server needs to be updated to 169.254.169.123, Secops firewall will block any other time server outside the one directly from amazon. The ntp-pool source was updated to point to amazon time server in /etc/chrony.d/ntp-pool.sources